### PR TITLE
1. OrderKafkaAdaptor.java

### DIFF
--- a/order/src/main/java/com/msa/order/framework/kafkaadpator/OrderKafkaAdaptor.java
+++ b/order/src/main/java/com/msa/order/framework/kafkaadpator/OrderKafkaAdaptor.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 
 @Slf4j
@@ -31,6 +32,7 @@ public class OrderKafkaAdaptor implements EventOutputPort {
     private final KafkaTemplate<String, ShippingInfoChanged> shippingInfoChangedKafkaTemplate;
 
     @Override
+    @TransactionalEventListener
     public void occurOrderCancelEvent(OrderCanceled orderCanceled) {
         orderCanceledKafkaTemplate.send(TOPIC_ORDER_CANCEL, orderCanceled)
                 .thenAccept(result -> log.info("resultOffset: [{}]", result.getRecordMetadata().hasOffset()))
@@ -41,6 +43,7 @@ public class OrderKafkaAdaptor implements EventOutputPort {
     }
 
     @Override
+    @TransactionalEventListener
     public void occurOrderCompletedEvent(OrderCompleted orderCompleted) {
         orderCompleteddKafkaTemplate.send(TOPIC_ORDER_COMPLETE, orderCompleted)
                 .thenAccept(result -> log.info("resultOffset: [{}]", result.getRecordMetadata().hasOffset()))
@@ -51,6 +54,7 @@ public class OrderKafkaAdaptor implements EventOutputPort {
     }
 
     @Override
+    @TransactionalEventListener
     public void occurShippingInfoChangedEvent(ShippingInfoChanged shippingInfoChanged) {
         shippingInfoChangedKafkaTemplate.send(TOPIC_SHIPPING_INFO_CHANGE, shippingInfoChanged)
                 .thenAccept(result -> log.info("resultOffset: [{}]", result.getRecordMetadata().hasOffset()))


### PR DESCRIPTION
Add @TransactionalEventListener to event methods

Annotated event-handling methods with @TransactionalEventListener to ensure they are triggered after transaction completion. This guarantees event consistency and prevents premature Kafka messaging in case of transaction failures.

## 연관된 이슈

> ex) #이슈번호

## 변경 사항

> 이번 PR에서 변경한 내용을 요약해서 작성해주세요.

### 스크린샷 (선택)

> 이미지, GIF 등의 작업 내용을 첨부합니다.

### 코멘트 (선택)

> 해결 할 버그, 이후 작업, 질문 등이 있을 경우 작성합니다. 